### PR TITLE
Changed korean female voice to the current updated version Papago uses

### DIFF
--- a/navertts/constants.py
+++ b/navertts/constants.py
@@ -19,7 +19,7 @@ SPEAKERS = {
     'es' : {'f' : 'carmen',
             'm' : 'jose'},
     'ja' : {'m' : 'shinji'},
-    'ko' : {'f' : 'mijin',
+    'ko' : {'f' : 'kyuri',
             'm' : 'jinho'},
     'zh' : {'f' : 'meimei',
             'm' : 'liangliang'},


### PR DESCRIPTION
The old Korean voice is robotic and the new one sounds much more natural. Found the voice from the website request URL when you press play "https://papago.naver.com/apis/tts/c_lt_6690-nvoice_kyuri_2.0.3_fc8d515a6e1d3f026161ce5b0343603b-1594486095707"